### PR TITLE
Rework timers in EM loop to ensure bunny runs promptly

### DIFF
--- a/lib/myxi/version.rb
+++ b/lib/myxi/version.rb
@@ -1,3 +1,3 @@
 module Myxi
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
Using Bunny in this library is a mistake, its threads seem incompatible with eventmachine. Better to switch to https://github.com/ruby-amqp/amqp but in the meantime this code forces EM to wake up regularly and yield control to Bunny's thread.